### PR TITLE
Elaborate on installation and configuration in README.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: Build
 on:
-  push: {}
-  pull_request: {}
+  workflow_dispatch:
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Git credential helper for KWallet
 
 ## Dependencies
-* KWallet for obvious reasons
+* KWallet for obvious reasons <br>(the *apt* packages `libkf5wallet5` and `libkf5wallet-dev`)
 * help2man as an optional dependency for generating man pages
 
 ## Install
@@ -17,11 +17,13 @@ sudo cmake --build . --target install
 
 ## Usage
 Configure as:
+```bash
+git config --global credentials.helper "kwallet --wallet kdewallet --folder git-credentials"
 ```
-[credential]
-    helper = kwallet
-```
-See also [gitcredentials](https://git-scm.com/docs/gitcredentials).
+You can replace `kdewallet` with your wallet and `git-credentials` with your folder name of choice.
+The folder will automatically be created. You can remove the `--global` switch if you want to configure the helper only for the current git repository.
+
+See also [gitcredentials](https://git-scm.com/docs/gitcredentials) and [git-credential](https://git-scm.com/docs/git-credential).
 
 `git-credential-kwallet` is a git credential helper, it is meant to be invoked by git, not manually.
 If you run into an issue and you want to investigate it by running the software directly, then be sure to close the input stream. e.g.:


### PR DESCRIPTION
The `.gitconfig` excerpt is replaced by a call to `git config` since this is more straight forward. The configuration using `.gitconfig` is explained in the link that is still included in the README.